### PR TITLE
fix asan typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CXXFLAGS ?= -std=c++2a
 ifeq ($(ASAN),1)
 	LDFLAGS += -fsanitize=address
 	CFLAGS += -fsanitize=address
-	CXXFLAGS += -fsanitize=undefined
+	CXXFLAGS += -fsanitize=address
 endif
 
 ifeq ($(UBSAN),1)


### PR DESCRIPTION
actually enable asan for c++, instead of enabling ubsan (probably a typo?)